### PR TITLE
Support POs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# Agent Instructions for H-BRS Cal Creator
+
+This is a monorepo with a **Kotlin/Spring Boot backend** and a **Next.js 15/React 19 frontend**.
+
+## Project Structure
+
+```
+├── backend/               # Spring Boot Kotlin application
+│   ├── src/main/kotlin/   # Production code
+│   └── src/test/kotlin/   # Test code
+├── frontend/              # Next.js 15 application
+│   ├── app/               # Next.js App Router pages
+│   ├── components/        # React components (ui/, teachingEvents/, semesters/)
+│   └── lib/               # Utilities and API hooks
+├── gradle/                # Gradle configuration
+└── docker-compose.yml     # Docker setup
+```
+
+## Build/Lint/Test Commands
+
+### Backend (Kotlin/Gradle)
+
+```bash
+# Run all tests
+./gradlew test
+
+# Build the application
+./gradlew build
+
+# Run the backend (development)
+./gradlew bootRun
+
+# Clean build
+./gradlew clean
+```
+
+### Frontend (Next.js)
+
+```bash
+# Install dependencies
+cd frontend && npm install
+
+# Format code with Prettier
+cd frontend && npm run prettier
+
+# Start production server
+cd frontend && npm start
+```
+
+## Code Style Guidelines
+
+### Kotlin Backend
+
+- **Formatting**: Kotlin uses standard formatting with 4-space indentation
+- **Naming**:
+    - Classes: `PascalCase` (e.g., `TeachingEventController`)
+    - Functions/properties: `camelCase` (e.g., `getAllTeachingEventsInteractor`)
+    - Interfaces: `PascalCase` with `*able` suffix when applicable
+    - Test classes: Same as production classes with `Test` suffix
+- **Architecture**: Clean Architecture with clear separation
+    - Controllers handle HTTP requests
+    - Interactors contain business logic
+    - Repositories handle data access
+    - Presenters format output
+- **Error Handling**: Use Kotlin's Result type or return null/empty for expected failures
+- **Coroutines**: Use `suspend` functions with `runBlocking` in tests
+- **Testing**: Use JUnit 5 with assertk for assertions and mockk for mocking
+
+### React/TypeScript Frontend
+
+- **Formatting**: Prettier with Vercel style guide + Tailwind plugin
+- **TypeScript**: Strict mode enabled; always define prop types
+- **Naming**:
+    - Components: `PascalCase` (e.g., `TeachingEvents.tsx`)
+    - Files: `kebab-case` (e.g., `teaching-events.tsx`)
+    - Hooks: `camelCase` with `use` prefix (e.g., `useTeachingEventSearching`)
+    - Utils: `camelCase` (e.g., `calendar.utils.ts`)
+- **Components**:
+    - Use `'use client'` directive for client components
+    - Prefer `React.FC` or `React.ComponentType` for component typing
+    - Use `Readonly<>` for immutable props
+    - Use `forwardRef` when ref forwarding is needed
+- **Styling**: Tailwind CSS with CSS variables for theming
+    - Use shadcn/ui component patterns
+    - Use `cn()` utility for merging classNames
+- **State**: Prefer React hooks (`useState`, `useEffect`) over external state management
+- **Imports**: Use `@/` path alias for project imports
+
+### General
+
+- Run `npm run prettier` before committing frontend changes
+- Run `./gradlew test` before committing backend changes
+- Keep functions small and focused
+- Write tests for new functionality
+- Use meaningful, descriptive names
+- Document complex business logic with comments
+
+## Tech Stack
+
+### Backend
+
+- Kotlin
+- Spring Boot (WebFlux)
+- Reactor for reactive programming
+- Apache POI for Excel parsing
+- SkrapeIt for HTML parsing
+- Biweekly for iCal generation
+- JUnit 5 + assertk + mockk for testing
+
+### Frontend
+
+- Next.js 15 (App Router, Turbopack)
+- React 19
+- TypeScript 5 (strict mode)
+- shadcn/ui

--- a/backend/src/main/kotlin/de/sotterbeck/hbrscalcreator/eva/DefaultCourseOfStudyPresenter.kt
+++ b/backend/src/main/kotlin/de/sotterbeck/hbrscalcreator/eva/DefaultCourseOfStudyPresenter.kt
@@ -41,13 +41,23 @@ class DefaultCourseOfStudyPresenter : CourseOfStudyPresenter {
         val abbreviation = semesterName.substringBefore(" ")
         val courseOfStudyName = getCourseOfStudyName(abbreviation)
 
-        val semesterNum = semesterName.substringAfter(" ").toIntOrNull() ?: 1
+        val semesterLabel = extractSemesterLabel(semesterName, abbreviation)
 
         return GetAllCoursesOfStudyInteractor.CourseOfStudyModel(
             name = courseOfStudyName,
             abbreviation = abbreviation,
-            semesters = setOf(semesterNum)
+            semesters = setOf(semesterLabel)
         )
+    }
+
+    private fun extractSemesterLabel(semesterName: String, abbreviation: String): String {
+        val label = semesterName.removePrefix(abbreviation).trim()
+        if (label.isNotEmpty()) {
+            return label
+        }
+
+        val number = semesterName.substringAfterLast(" ").toIntOrNull()
+        return number?.toString() ?: "1"
     }
 
     private fun getCourseOfStudyName(abbreviation: String): String {

--- a/backend/src/main/kotlin/de/sotterbeck/hbrscalcreator/eva/GetAllCoursesOfStudyInteractor.kt
+++ b/backend/src/main/kotlin/de/sotterbeck/hbrscalcreator/eva/GetAllCoursesOfStudyInteractor.kt
@@ -11,6 +11,6 @@ interface GetAllCoursesOfStudyInteractor {
     data class CourseOfStudyModel(
         val name: String,
         val abbreviation: String,
-        val semesters: Set<Int>
+        val semesters: Set<String>
     )
 }

--- a/backend/src/test/kotlin/de/sotterbeck/hbrscalcreator/eva/DefaultCourseOfStudyPresenterTest.kt
+++ b/backend/src/test/kotlin/de/sotterbeck/hbrscalcreator/eva/DefaultCourseOfStudyPresenterTest.kt
@@ -14,6 +14,7 @@ class DefaultCourseOfStudyPresenterTest {
         val semesters = listOf(
             SemesterDto("BCSP 1", "#SPLUS42C544"),
             SemesterDto("BCSP 2", "#SPLUSD4951B"),
+            SemesterDto("BCSP 2 (PO 2021)", "#SPLUS098663"),
             SemesterDto("BCSP 3", "#SPLUS42C545"),
             SemesterDto("BCSP 4", "#SPLUS4BB425"),
             SemesterDto("BI 1", "#SPLUS42C53D"),
@@ -21,6 +22,7 @@ class DefaultCourseOfStudyPresenterTest {
             SemesterDto("BI 3", "#SPLUS42C53E"),
             SemesterDto("BI 4", "BCS4"),
             SemesterDto("BI 5", "#SPLUS42C53F"),
+            SemesterDto("BI 5 (PO 2017)", "#SPLUS42C99F"),
             SemesterDto("BWI 1", "#SPLUS42C541"),
             SemesterDto("BWI 2", "BBIS2"),
             SemesterDto("BWI 4", "BBIS4"),
@@ -34,6 +36,7 @@ class DefaultCourseOfStudyPresenterTest {
             SemesterDto("MI 1", "MCS1"),
             SemesterDto("MI 2", "MCS2"),
             SemesterDto("MI 3", "MCS3"),
+            SemesterDto("MI 3 (PO 2021)", "#SPLUS4D0F01"),
             SemesterDto("MVG 1", "#SPLUS157A20"),
             SemesterDto("MVG 2", "#SPLUSAC7DD0"),
             SemesterDto("MVG 3", "#SPLUSAC7DD1"),
@@ -45,37 +48,37 @@ class DefaultCourseOfStudyPresenterTest {
             CourseOfStudyModel(
                 name = "Bachelor Cyber Security & Privacy",
                 abbreviation = "BCSP",
-                semesters = setOf(1, 2, 3, 4)
+                semesters = setOf("1", "2", "2 (PO 2021)", "3", "4")
             ),
             CourseOfStudyModel(
                 name = "Bachelor Informatik",
                 abbreviation = "BI",
-                semesters = setOf(1, 2, 3, 4, 5)
+                semesters = setOf("1", "2", "3", "4", "5", "5 (PO 2017)")
             ),
             CourseOfStudyModel(
                 name = "Bachelor Wirtschaftsinformatik",
                 abbreviation = "BWI",
-                semesters = setOf(1, 2, 4, 5)
+                semesters = setOf("1", "2", "4", "5")
             ),
             CourseOfStudyModel(
                 name = "Master Autonomous Systems",
                 abbreviation = "MAS",
-                semesters = setOf(1, 2, 3, 4)
+                semesters = setOf("1", "2", "3", "4")
             ),
             CourseOfStudyModel(
                 name = "Master Cyber Security & Privacy",
                 abbreviation = "MCSP",
-                semesters = setOf(1, 2)
+                semesters = setOf("1", "2")
             ),
             CourseOfStudyModel(
                 name = "Master Informatik",
                 abbreviation = "MI",
-                semesters = setOf(1, 2, 3)
+                semesters = setOf("1", "2", "3", "3 (PO 2021)")
             ),
             CourseOfStudyModel(
                 name = "Master Visual Computing & Games Technology",
                 abbreviation = "MVG",
-                semesters = setOf(1, 2, 3)
+                semesters = setOf("1", "2", "3")
             ),
         )
     }
@@ -84,7 +87,9 @@ class DefaultCourseOfStudyPresenterTest {
     fun `should combine courses of study with a single semester`() {
         val semesters = listOf(
             SemesterDto("MKSN", "#SPLUS4222DA"),
-            SemesterDto("Zusatzveranstaltungen", "#SPLUS382187")
+            SemesterDto("Zusatzveranstaltungen", "#SPLUS382187"),
+            SemesterDto("Sprachkurse", "#SPLUS4D9B44"),
+            SemesterDto("Wahlpflicht", "#SPLUS4D9B45")
         )
 
         val coursesOfStudy = uut.presentCoursesOfStudy(semesters).data
@@ -93,12 +98,22 @@ class DefaultCourseOfStudyPresenterTest {
             CourseOfStudyModel(
                 name = "Master Communication Systems and Networks",
                 abbreviation = "MKSN",
-                semesters = setOf(1)
+                semesters = setOf("1")
             ),
             CourseOfStudyModel(
                 name = "Zusatzveranstaltungen",
                 abbreviation = "Zusatzveranstaltungen",
-                semesters = setOf(1)
+                semesters = setOf("1")
+            ),
+            CourseOfStudyModel(
+                name = "Sprachkurse",
+                abbreviation = "Sprachkurse",
+                semesters = setOf("1")
+            ),
+            CourseOfStudyModel(
+                name = "Wahlpflicht",
+                abbreviation = "Wahlpflicht",
+                semesters = setOf("1")
             )
         )
     }

--- a/backend/src/test/kotlin/de/sotterbeck/hbrscalcreator/eva/EvaInfoRepositoryImplTest.kt
+++ b/backend/src/test/kotlin/de/sotterbeck/hbrscalcreator/eva/EvaInfoRepositoryImplTest.kt
@@ -64,6 +64,7 @@ class EvaInfoRepositoryImplTest {
         val semesters = listOf(
             SemesterDto("BCSP 1", "#SPLUS42C544"),
             SemesterDto("BCSP 2", "#SPLUSD4951B"),
+            SemesterDto("BCSP 2 (PO 2021)", "#SPLUS098663"),
             SemesterDto("BCSP 3", "#SPLUS42C545"),
             SemesterDto("BCSP 4", "#SPLUS4BB425")
         )
@@ -89,14 +90,15 @@ class EvaInfoRepositoryImplTest {
         val semesters = listOf(
             SemesterDto("BCSP 1", "#SPLUS42C544"),
             SemesterDto("BCSP 2", "#SPLUSD4951B"),
+            SemesterDto("BCSP 2 (PO 2021)", "#SPLUS098663"),
             SemesterDto("BCSP 3", "#SPLUS42C545"),
             SemesterDto("BCSP 4", "#SPLUS4BB425")
         )
         coEvery { semestersExtractor.extractSemesters(MockEvaDispatcher.mainPageHtml) } returns semesters
 
-        val result = runBlocking { uut.findEvaIdByToken("BCSP1") }
+        val result = runBlocking { uut.findEvaIdByToken("BCSP2(PO2021)") }
 
-        assertThat(result).isEqualTo("#SPLUS42C544")
+        assertThat(result).isEqualTo("#SPLUS098663")
     }
 
     @Test

--- a/backend/src/test/kotlin/de/sotterbeck/hbrscalcreator/eva/GetAllSemesterNamesInteractorImplTest.kt
+++ b/backend/src/test/kotlin/de/sotterbeck/hbrscalcreator/eva/GetAllSemesterNamesInteractorImplTest.kt
@@ -20,6 +20,7 @@ class GetAllSemesterNamesInteractorImplTest {
         coEvery { evaInfoRepository.findAllSemesters() } returns listOf(
             SemesterDto("BCSP 1", "#SPLUS42C544"),
             SemesterDto("BCSP 2", "#SPLUSD4951B"),
+            SemesterDto("BCSP 2 (PO 2021)", "#SPLUS098663"),
             SemesterDto("BCSP 3", "#SPLUS42C545"),
             SemesterDto("BCSP 4", "#SPLUS4BB425"),
             SemesterDto("BI 1", "#SPLUS42C53D"),
@@ -66,6 +67,7 @@ class GetAllSemesterNamesInteractorImplTest {
         assertThat(response.data).containsExactlyInAnyOrder(
             "BCSP 1",
             "BCSP 2",
+            "BCSP 2 (PO 2021)",
             "BCSP 3",
             "BCSP 4",
             "BI 1",

--- a/backend/src/test/kotlin/de/sotterbeck/hbrscalcreator/eva/htmlParsing/SkrapeItSemestersExtractorTest.kt
+++ b/backend/src/test/kotlin/de/sotterbeck/hbrscalcreator/eva/htmlParsing/SkrapeItSemestersExtractorTest.kt
@@ -65,8 +65,9 @@ class SkrapeItSemestersExtractorTest {
                       <option value="">*** bitte auswählen ***</option>
                       <option value="#SPLUS42C544">BCSP 1</option>
                       <option value="#SPLUSD4951B">BCSP 2</option>
+                      <option value="#SPLUS098663">BCSP 2 (PO 2021)</option>
                       <option value="#SPLUS42C545">BCSP 3</option>
-                      <option value="#SPLUS4BB425">BCSP 4</option>
+                      <option value="#SPLUS4BB425">BCSP 4 (PO 2021)</option>
                       <option value="#SPLUS42C53D">BI 1</option>
                       <option value="BCS2">BI 2</option>
                       <option value="#SPLUS42C53E">BI 3</option>
@@ -116,8 +117,9 @@ class SkrapeItSemestersExtractorTest {
             listOf(
                 SemesterDto("BCSP 1", "#SPLUS42C544"),
                 SemesterDto("BCSP 2", "#SPLUSD4951B"),
+                SemesterDto("BCSP 2 (PO 2021)", "#SPLUS098663"),
                 SemesterDto("BCSP 3", "#SPLUS42C545"),
-                SemesterDto("BCSP 4", "#SPLUS4BB425"),
+                SemesterDto("BCSP 4 (PO 2021)", "#SPLUS4BB425"),
                 SemesterDto("BI 1", "#SPLUS42C53D"),
                 SemesterDto("BI 2", "BCS2"),
                 SemesterDto("BI 3", "#SPLUS42C53E"),

--- a/frontend/app/semesters/page.tsx
+++ b/frontend/app/semesters/page.tsx
@@ -23,6 +23,10 @@ export default async function Page(props: {
           courses={coursesOfStudiesResponse.data}
           className="container pt-6"
         />
+        <div className="container flex items-center gap-2 py-4">
+          <div className="size-4 rounded bg-amber-600 dark:bg-amber-400" />
+          <span className="text-muted-foreground">Alte Prüfungsordnung</span>
+        </div>
         <div className="sticky bottom-0 left-0 right-0 bg-gradient-to-t from-zinc-50 py-6 dark:from-background md:invisible">
           <div className="container flex justify-end">
             <ContinueButton />

--- a/frontend/components/semesters/semester-card.tsx
+++ b/frontend/components/semesters/semester-card.tsx
@@ -14,6 +14,13 @@ import {
   useSearchParams,
 } from 'next/navigation';
 import { getSelectedSemesters } from '@/lib/semester/selectedSemestersParams';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 
 export function SemesterCard({
   course,
@@ -54,13 +61,37 @@ export function SemesterCard({
             readOnlySearchParams,
           )}
         >
-          {course.semesters.map((semester) => {
-            return (
-              <ToggleGroupItem key={semester} value={semester.toString()}>
-                {semester}
-              </ToggleGroupItem>
-            );
-          })}
+          <TooltipProvider>
+            {course.semesters.map((semester) => {
+              const semesterValue = normalizeSemesterValue(semester);
+              const { displayLabel, poYear } = parseSemesterLabel(semester);
+              const isOldPo = Boolean(poYear);
+              const toggleItem = (
+                <ToggleGroupItem
+                  key={semesterValue}
+                  value={semesterValue}
+                  className={cn(
+                    isOldPo && 'text-amber-600 dark:text-amber-400',
+                  )}
+                >
+                  {displayLabel}
+                </ToggleGroupItem>
+              );
+
+              if (!isOldPo) {
+                return toggleItem;
+              }
+
+              return (
+                <Tooltip key={semesterValue}>
+                  <TooltipTrigger asChild>{toggleItem}</TooltipTrigger>
+                  <TooltipContent>
+                    <p>PO {poYear}</p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </TooltipProvider>
         </ToggleGroup>
       </CardContent>
     </Card>
@@ -68,7 +99,9 @@ export function SemesterCard({
 }
 
 function getCourseIds(abbreviation: string, semesters: string[]) {
-  return semesters.map((semester) => `${abbreviation}${semester}`);
+  return semesters.map((semester) =>
+    normalizeSemesterToken(`${abbreviation}${semester}`),
+  );
 }
 
 function getSelectedCourseSemesters(
@@ -82,7 +115,30 @@ function getSelectedCourseSemesters(
 
   return selectedSemesters
     .filter((semester) => semester.startsWith(abbreviation))
-    .map((semester) => semester.replace(abbreviation, ''));
+    .map((semester) => semester.replace(abbreviation, '').trim());
+}
+
+function normalizeSemesterToken(semesterName: string): string {
+  return semesterName.replaceAll(' ', '');
+}
+
+function normalizeSemesterValue(semesterLabel: string): string {
+  return semesterLabel.replaceAll(' ', '');
+}
+
+function parseSemesterLabel(semesterLabel: string): {
+  displayLabel: string;
+  poYear?: string;
+} {
+  const match = semesterLabel.match(/^(\d+)\s*(?:\(PO\s*(\d{4})\))?/);
+  if (match) {
+    return {
+      displayLabel: match[1],
+      poYear: match[2] ?? undefined,
+    };
+  }
+
+  return { displayLabel: semesterLabel };
 }
 
 function updateSelectedSemestersInParams(

--- a/frontend/components/semesters/semester-card.tsx
+++ b/frontend/components/semesters/semester-card.tsx
@@ -15,6 +15,10 @@ import {
 } from 'next/navigation';
 import { getSelectedSemesters } from '@/lib/semester/selectedSemestersParams';
 import {
+  normalizeSemesterToken,
+  parseSemesterLabel,
+} from '@/lib/semester/semesterLabel';
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -63,32 +67,34 @@ export function SemesterCard({
         >
           <TooltipProvider>
             {course.semesters.map((semester) => {
-              const semesterValue = normalizeSemesterValue(semester);
+              const semesterValue = normalizeSemesterToken(semester);
               const { displayLabel, poYear } = parseSemesterLabel(semester);
               const isOldPo = Boolean(poYear);
-              const toggleItem = (
-                <ToggleGroupItem
-                  key={semesterValue}
-                  value={semesterValue}
-                  className={cn(
-                    isOldPo && 'text-amber-600 dark:text-amber-400',
-                  )}
-                >
-                  {displayLabel}
-                </ToggleGroupItem>
-              );
-
               if (!isOldPo) {
-                return toggleItem;
+                return (
+                  <ToggleGroupItem key={semesterValue} value={semesterValue}>
+                    {displayLabel}
+                  </ToggleGroupItem>
+                );
               }
 
               return (
-                <Tooltip key={semesterValue}>
-                  <TooltipTrigger asChild>{toggleItem}</TooltipTrigger>
-                  <TooltipContent>
-                    <p>PO {poYear}</p>
-                  </TooltipContent>
-                </Tooltip>
+                <ToggleGroupItem
+                  key={semesterValue}
+                  value={semesterValue}
+                  className={cn('text-amber-600 dark:text-amber-400')}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex h-full w-full items-center justify-center">
+                        {displayLabel}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>PO {poYear}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </ToggleGroupItem>
               );
             })}
           </TooltipProvider>
@@ -115,30 +121,9 @@ function getSelectedCourseSemesters(
 
   return selectedSemesters
     .filter((semester) => semester.startsWith(abbreviation))
-    .map((semester) => semester.replace(abbreviation, '').trim());
-}
-
-function normalizeSemesterToken(semesterName: string): string {
-  return semesterName.replaceAll(' ', '');
-}
-
-function normalizeSemesterValue(semesterLabel: string): string {
-  return semesterLabel.replaceAll(' ', '');
-}
-
-function parseSemesterLabel(semesterLabel: string): {
-  displayLabel: string;
-  poYear?: string;
-} {
-  const match = semesterLabel.match(/^(\d+)\s*(?:\(PO\s*(\d{4})\))?/);
-  if (match) {
-    return {
-      displayLabel: match[1],
-      poYear: match[2] ?? undefined,
-    };
-  }
-
-  return { displayLabel: semesterLabel };
+    .map((semester) =>
+      normalizeSemesterToken(semester.replace(abbreviation, '').trim()),
+    );
 }
 
 function updateSelectedSemestersInParams(

--- a/frontend/components/teachingEvents/select/filter/semester-filter.tsx
+++ b/frontend/components/teachingEvents/select/filter/semester-filter.tsx
@@ -6,6 +6,7 @@ import {
   getSelectedSemesters,
   removeSemesterFromParams,
 } from '@/lib/semester/selectedSemestersParams';
+import { normalizeSemesterToken } from '@/lib/semester/semesterLabel';
 import { Button } from '@/components/ui/button';
 import { useSearchParamsManipulation } from '@/lib/common/useSearchParamsManipulation';
 import { useState } from 'react';
@@ -97,8 +98,4 @@ function SemesterCheckbox({
       </label>
     </div>
   );
-}
-
-function normalizeSemesterToken(semesterName: string): string {
-  return semesterName.replaceAll(' ', '');
 }

--- a/frontend/components/teachingEvents/select/filter/semester-filter.tsx
+++ b/frontend/components/teachingEvents/select/filter/semester-filter.tsx
@@ -45,7 +45,7 @@ export function SemesterFilter({
       <p className="font-medium">Semester</p>
       {semesters.map((semester) => (
         <SemesterCheckbox
-          key={semester.replace(' ', '')}
+          key={normalizeSemesterToken(semester)}
           semester={semester}
           selectedSemesterIds={selectedSemesterIds}
           searchParams={readonlyURLSearchParams}
@@ -72,7 +72,7 @@ function SemesterCheckbox({
   pathname,
   replace,
 }: Readonly<SemesterCheckboxProps>) {
-  const semesterToken = semester.replace(' ', '');
+  const semesterToken = normalizeSemesterToken(semester);
 
   function handleCheckedChange(checked: boolean) {
     const params = checked
@@ -97,4 +97,8 @@ function SemesterCheckbox({
       </label>
     </div>
   );
+}
+
+function normalizeSemesterToken(semesterName: string): string {
+  return semesterName.replaceAll(' ', '');
 }

--- a/frontend/lib/api/apiReponses.ts
+++ b/frontend/lib/api/apiReponses.ts
@@ -5,7 +5,7 @@ interface CoursesOfStudyResponse {
 interface CourseOfStudyModel {
   name: string;
   abbreviation: string;
-  semesters: number[];
+  semesters: string[];
 }
 
 interface SemesterNamesResponse {

--- a/frontend/lib/semester/semesterLabel.ts
+++ b/frontend/lib/semester/semesterLabel.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalizes a semester name by removing all spaces.
+ * @param semesterName The semester name to normalize.
+ */
+export function normalizeSemesterToken(semesterName: string): string {
+  return semesterName.replaceAll(' ', '');
+}
+
+/**
+ * Parses a semester label into a display label and optional PO year.
+ * @param semesterLabel The semester label to parse.
+ */
+export function parseSemesterLabel(semesterLabel: string): {
+  displayLabel: string;
+  poYear?: string;
+} {
+  const match = semesterLabel.match(/^(\d+)\s*(?:\(PO\s*(\d{4})\))?/);
+  if (match) {
+    return {
+      displayLabel: match[1],
+      poYear: match[2] ?? undefined,
+    };
+  }
+
+  return { displayLabel: semesterLabel };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "hbrs-cal-creator",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This pull request introduces improved support for semesters with additional labels, such as those indicating different examination regulations (e.g., "2 (PO 2021)"), across both the backend and frontend. The changes update how semester labels are parsed, stored, and displayed, ensuring that non-numeric semester identifiers are handled correctly throughout the application.

The frontend now visually distinguishes semesters with older examination regulations and provides tooltips for clarification. Comprehensive updates to tests and documentation are included to reflect these enhancements.